### PR TITLE
Update docs reference to "master"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule Colorex.MixProject do
       # The main page in the docs
       main: "Colorex",
       extras: ["README.md", "NamedColors.md"],
-      before_closing_body_tag: &before_closing_body_tag/1
+      before_closing_body_tag: &before_closing_body_tag/1,
+      source_ref: "master"
     ]
   end
 


### PR DESCRIPTION
Hey,
to make the link from Hexdocs to GitHub work, we have to update the source_ref field because ExDoc defaults to the main branch